### PR TITLE
Improve-travis-built-time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-application/node_modules
 application/coverage
 .git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] ; then ./travis_scripts/install_compose.sh ; fi
 - cd application
 before_script:
+- npm update --dev
 - npm run start:mongodb
 script:
 - sleep 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /nodeApp
 #   Installation   #
 # ---------------- #
 
-ADD ./application/package.json ./
-RUN npm install --production
+ADD ./application/ ./
+RUN npm prune --production
 
 ADD ./application/ ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ WORKDIR /nodeApp
 ADD ./application/ ./
 RUN npm prune --production
 
-ADD ./application/ ./
-
 # ----------------- #
 #   Configuration   #
 # ----------------- #


### PR DESCRIPTION
I've implemented a more efficient version for installing NPM packages. They are now only updated (or downloaded if cache is missing) and are not downloaded a second time as part of the `docker build` execution. The actual image content stays the same.
By updating the packages as part of the Travis run, we also gain more security as the software will be tested against the exact same packages as installed in the docker image.

There might be another improvement: I could try to export the MongoDB image at the end of Travis execution, cache it and reimport it before executing another `npm run start:mongodb`. Thus Docker would not need to download a recent version of MongoDB on each Travis build. Downside: We might miss a MongoDB update (but we could implement a script for this).
Downloading MongoDB on my local system via network: ~16 secs (Travis shows ~14 secs)
Save an image on my local system: ~7 secs
Reimport an image from my local system: ~8 secs (I have a fast SSD, don't know what Travis uses)

Is it worth trying to implement and measure it at Travis?