### PR TITLE
SWIK-1818 Upgraded Travis NodeJS runtime to v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 6
+node_js: 8
 sudo: required
 git:
   depth: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8-slim
 MAINTAINER Roy Meissner <meissner@informatik.uni-leipzig.de>
 
 ARG BUILD_ENV=local


### PR DESCRIPTION
I've upgraded the NodeJS runtime to v8 (currently LTS) on Travis and for the platform-runtime.

Still testing, do not merge as of now.