### PR TITLE
Update dependencies

### DIFF
--- a/application/.eslintrc
+++ b/application/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 7,
+    "ecmaVersion": 8,
     "ecmaFeatures": {
       "blockBindings": true,
       "arrowFunctions": true,
@@ -14,6 +14,7 @@
     "es6": true,
     "mocha": true
   },
+  "plugins": ["promise"],
   "rules": {
     "strict": [2, "global"],
     "arrow-spacing": [2, { "before": true, "after": true }],
@@ -41,6 +42,5 @@
     "promise/no-native": "off",
     "promise/no-promise-in-callback": "warn",
     "promise/no-callback-in-promise": "warn"
-  },
-  "plugins": ["promise"]
+  }
 }

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -11,41 +11,44 @@ const boom = require('boom'), //Boom gives us some predefined http codes and pro
 
 module.exports = {
   //Get slide from database or return NOT FOUND
-  getSlide: function(request, reply) {
-    slideDB.get(encodeURIComponent(request.params.id)).then((slide) => {
+  getSlide: async function(request) {
+    try {
+      let slide = await slideDB.get(encodeURIComponent(request.params.id));
       if (co.isEmpty(slide))
-        reply(boom.notFound());
+        return boom.notFound();
       else
-        reply(co.rewriteID(slide));
-    }).catch((error) => {
+        return co.rewriteID(slide);
+    } catch(error) {
       request.log('error', error);
-      reply(boom.badImplementation());
-    });
+      return boom.badImplementation();
+    }
   },
 
   //Create Slide with new id and payload or return INTERNAL_SERVER_ERROR
-  newSlide: function(request, reply) {
-    slideDB.insert(request.payload).then((inserted) => {
+  newSlide: async function(request) {
+    try{
+      let inserted = await slideDB.insert(request.payload);
       if (co.isEmpty(inserted.ops[0]))
         throw inserted;
       else
-        reply(co.rewriteID(inserted.ops[0]));
-    }).catch((error) => {
+        return co.rewriteID(inserted.ops[0]);
+    } catch(error) {
       request.log('error', error);
-      reply(boom.badImplementation());
-    });
+      return boom.badImplementation();
+    }
   },
 
   //Update Slide with id id and payload or return INTERNAL_SERVER_ERROR
-  replaceSlide: function(request, reply) {
-    slideDB.replace(encodeURIComponent(request.params.id), request.payload).then((replaced) => {
+  replaceSlide: async function(request) {
+    try {
+      let replaced = await slideDB.replace(encodeURIComponent(request.params.id), request.payload);
       if (co.isEmpty(replaced.value))
         throw replaced;
       else
-        reply(replaced.value);
-    }).catch((error) => {
+        return replaced.value;
+    } catch (error) {
       request.log('error', error);
-      reply(boom.badImplementation());
-    });
+      return boom.badImplementation();
+    }
   },
 };

--- a/application/package.json
+++ b/application/package.json
@@ -13,9 +13,9 @@
   "scripts": {
     "clean": "rm -R ./node_modules/ ./coverage/",
     "lint": "eslint -c .eslintrc \"./**/*.js\"",
-    "test": "NODE_ENV=test mocha ./tests/*.js",
-    "test:unit": "NODE_ENV=test mocha ./tests/unit_*.js",
-    "test:integration": "NODE_ENV=test mocha ./tests/integration_*.js",
+    "test": "NODE_ENV=test mocha --exit ./tests/*.js",
+    "test:unit": "NODE_ENV=test mocha --exit ./tests/unit_*.js",
+    "test:integration": "NODE_ENV=test mocha --exit ./tests/integration_*.js",
     "coverage": "nyc npm test",
     "coverall": "npm run coverage && nyc report --reporter=text-lcov | coveralls && rm -rf ./.nyc_output",
     "countLOC": "sloc -f cli-table -k total,source,comment,empty -e node_modules\\|coverage ./",
@@ -25,18 +25,18 @@
     "stop:mongodb": "docker stop mongotest && docker rm mongotest"
   },
   "dependencies": {
-    "ajv": "^5.1.0",
-    "boom": "^5.1.0",
+    "ajv": "^6.5.0",
+    "boom": "^7.2.0",
     "database-cleaner": "^1.2.0",
-    "good": "^7.2.0",
-    "good-console": "^6.2.0",
+    "good": "^8.1.0",
+    "good-console": "^7.1.0",
     "good-squeeze": "^5.0.0",
-    "hapi": "^16.4.0",
-    "hapi-swagger": "^7.6.0",
-    "inert": "^4.2.0",
-    "joi": "^10.6.0",
+    "hapi": "^17.6.0",
+    "hapi-swagger": "^9.1.0",
+    "inert": "^5.1.0",
+    "joi": "^13.7.0",
     "mongodb": "^2.2.28",
-    "vision": "^4.1.0"
+    "vision": "^5.4.0"
   },
   "engines": {
     "node": ">=6.11.0"
@@ -45,11 +45,11 @@
     "chai": "^4.0.0",
     "chai-as-promised": "^7.0.0",
     "coveralls": "^3.0.0",
-    "eslint": "^4.0.0",
-    "eslint-plugin-promise": "^3.4.0",
-    "mocha": "^3.4.0",
+    "eslint": "^5.6.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "mocha": "^5.2.0",
     "nodemon": "^1.11.0",
-    "nyc": "^11.6.0",
+    "nyc": "^13.0.0",
     "pre-commit": "^1.2.0",
     "sloc": "^0.2.0"
   },

--- a/application/routes.js
+++ b/application/routes.js
@@ -13,7 +13,7 @@ module.exports = function(server) {
     method: 'GET',
     path: '/slide/{id}',
     handler: handlers.getSlide,
-    config: {
+    options: {
       validate: {
         params: {
           id: Joi.string().alphanum().lowercase()
@@ -29,7 +29,7 @@ module.exports = function(server) {
     method: 'POST',
     path: '/slide/new',
     handler: handlers.newSlide,
-    config: {
+    options: {
       validate: {
         payload: Joi.object().keys({
           title: Joi.string(),
@@ -52,7 +52,7 @@ module.exports = function(server) {
     method: 'PUT',
     path: '/slide/{id}',
     handler: handlers.replaceSlide,
-    config: {
+    options: {
       validate: {
         params: {
           id: Joi.string().alphanum().lowercase()

--- a/application/tests/integration_newSlide.js
+++ b/application/tests/integration_newSlide.js
@@ -12,8 +12,7 @@ describe('REST API', () => {
     Object.keys(require.cache).forEach((key) => delete require.cache[key]);
     require('chai').should();
     let hapi = require('hapi');
-    server = new hapi.Server();
-    server.connection({
+    server = hapi.Server({
       host: 'localhost',
       port: 3000
     });
@@ -36,17 +35,15 @@ describe('REST API', () => {
   };
 
   context('when creating a slide it', () => {
-    it('should reply it', (done) => {
-      server.inject(options, (response) => {
-        response.should.be.an('object').and.contain.keys('statusCode','payload');
-        response.statusCode.should.equal(200);
-        response.payload.should.be.a('string');
-        let payload = JSON.parse(response.payload);
-        payload.should.be.an('object').and.contain.keys('title', 'language');
-        payload.title.should.equal('Dummy');
-        payload.language.should.equal('en');
-        done();
-      });
+    it('should reply it', async () => {
+      let response = await server.inject(options);
+      response.should.be.an('object').and.contain.keys('statusCode','payload');
+      response.statusCode.should.equal(200);
+      response.payload.should.be.a('string');
+      let payload = JSON.parse(response.payload);
+      payload.should.be.an('object').and.contain.keys('title', 'language');
+      payload.title.should.equal('Dummy');
+      payload.language.should.equal('en');
     });
   });
 });


### PR DESCRIPTION
I've updated all dependencies except for MongoDB (not sure what I need to change for MongoDB).

Hapi 17 isn't supporting a response object anymore, but instead relies on async/await statements and to return the object to respond. I've adapted the respective methods. This also affects how tests are written.

Hapi 17 is initialised differently. The only thing I wasn't able to find is how to the following line must be implemented in Hapi 17:
`const server = new hapi.Server({ connections: {routes: {validate: { options: {convert : false}}}}});`
Thus I omitted the option.

If I remember right, updating mocha resolved the two vulnerabilities.